### PR TITLE
Convert from bluepy to bleak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.venv

--- a/README.md
+++ b/README.md
@@ -28,27 +28,29 @@ This repo is now in hacs, so just search for it, install and enjoy automatic upd
 
 ## Give bluetooth permissions for device scanning !
 
-This component use the `bluepy` python library to access bluetooth. In order to scan for new devices, it needs to have the correct permissions:
-  - For Home-assistant core installed in Virtualenv:
+Since version 0.12.0, this component uses the `bleak` python library to access bluetooth. In order to scan and interact with devices, on linux bluez utility needs to be installed and also to have the correct permissions:
+  - for **Home Assistant Operating System**:
+    It should be all setup, at least for HA 2022.7+
 
-    ```
-    sudo setcap cap_net_admin,cap_net_raw+eip /PATH-TO-HA-VENV/PATH-TO-BLUEPY-LIB/bluepy-helper
-    ```
+  - For **Home Assistant Container** in docker:
 
-  - For Home-assistant core in docker:
-
-    The docker-compose (or equivalent docker command) should have:
+    Ensure your host has the `bluetoothctl` binary on the system (coming from `bluez` or `bluez-util` package, depending on the distro).  
+    The docker-compose container (or equivalent docker command) should link */var/run/dbus* with host folder through a volume and *NET_ADMIN* permission is needed. docker compose extract:
 
     ```yaml
+    volumes:
+      - /var/run/dbus:/var/run/dbus
     cap_add:
      - NET_ADMIN
      - NET_RAW
     network_mode: host
     ```
 
-  - for HASSIO:
+  - For **Home Assistant Core** installed in a Virtualenv:
+  
+  Ensure your host has the `bluetoothctl` binary on the system (coming from `bluez` or `bluez-util` package, depending on the distro).  
+  Make sure the user running HA belongs to the `bluetooth` group.
 
-    Not too sure yet... It may have the correct permissions already ??
 
 # Homeassistant component configuration
 
@@ -89,11 +91,12 @@ Once paired you can control the lamp through HA
 - [x] Re-implement bluetooth backend for stability and optimal responsivness for yeelight
 - [x] Add component to HACS for easy install
 - [x] Allow configuration through the integration UI
-- [ ] Enable discovery of lamps in UI? (Not sure if possible)
+- [x] Enable discovery of lamps in UI
 - [ ] Look into setting up effect and flow (low priority)
 - [x] Allow pairing process with new device
 - [ ] Support for candela light? (I do not have a device, so might need help from someone with one...)
 - [x] Scale temperature range so that it matches HA UI
+- [x] Use bleak for bluetooth library
 
 # Debugging
 

--- a/custom_components/yeelight_bt/config_flow.py
+++ b/custom_components/yeelight_bt/config_flow.py
@@ -9,8 +9,7 @@ from .const import DOMAIN, CONF_ENTRY_METHOD, CONF_ENTRY_SCAN, CONF_ENTRY_MANUAL
 
 from .yeelightbt import (
     discover_yeelight_lamps,
-    BTLEDisconnectError,
-    BTLEManagementError,
+    BleakError,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,14 +51,10 @@ class Yeelight_btConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
             return self.async_show_form(step_id="scan")
         _LOGGER.debug("Starting a scan for Yeelight Bt devices")
         try:
-            devices = await self.hass.async_add_executor_job(discover_yeelight_lamps)
-        except BTLEDisconnectError as err:
+            devices = await discover_yeelight_lamps()
+        except BleakError as err:
             _LOGGER.error(f"Bluetooth connection error while trying to scan: {err}")
-            errors["base"] = "BTLEDisconnectError"
-            return self.async_show_form(step_id="scan", errors=errors)
-        except BTLEManagementError as err:
-            _LOGGER.error(f"Bluetooth connection error while trying to scan: {err}")
-            errors["base"] = "BTLEManagementError"
+            errors["base"] = "BleakError"
             return self.async_show_form(step_id="scan", errors=errors)
 
         if not devices:

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -87,7 +87,7 @@ class YeelightBT(LightEntity):
         self._effect = "none"
         self._available = False
 
-        _LOGGER.info(f"Initializing {self.name}, {self._mac}")
+        _LOGGER.info(f"Initializing YeelightBT Entity: {self.name}, {self._mac}")
         self._dev = Lamp(self._mac)
         self._dev.add_callback_on_state_changed(self._status_cb)
         self._prop_min_max = self._dev.get_prop_min_max()

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -47,7 +47,7 @@ SUPPORT_YEELIGHT_BEDSIDE = SUPPORT_YEELIGHT_BT | SUPPORT_COLOR_TEMP | SUPPORT_CO
 _LOGGER = logging.getLogger(__name__)
 
 
-def async_setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Setup the yeelightbt light platform."""
     mac = config[CONF_MAC]
     name = config[CONF_NAME]

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -210,7 +210,7 @@ class YeelightBT(LightEntity):
         _LOGGER.debug("Got state notification from the lamp")
         self._available = self._dev.available
         if not self._available:
-            self.async_schedule_update_ha_state()
+            self.async_write_ha_state()
             return
 
         self._brightness = int(round(255.0 * self._dev.brightness / 100))
@@ -222,8 +222,8 @@ class YeelightBT(LightEntity):
         else:
             self._ct = None
             self._rgb = self._dev.color
-
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
+        
 
     async def async_update(self):
         # Note, update should only start fetching,

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -261,7 +261,7 @@ class YeelightBT(LightEntity):
                 f"Trying to set color RGB:{rgb} with brighntess:{brightness_dev}"
             )
             await self._dev.set_color(*rgb, brightness=brightness_dev)
-            self._brightness = brightness
+            self._brightness = self._dev._brightness
             return
 
         if ATTR_COLOR_TEMP in kwargs:
@@ -273,13 +273,13 @@ class YeelightBT(LightEntity):
             )
             await self._dev.set_temperature(scaled_temp_in_k, brightness=brightness_dev)
             self._ct = mireds
-            self._brightness = brightness
+            self._brightness = self._dev._brightness
             return
 
         if ATTR_BRIGHTNESS in kwargs:
             _LOGGER.debug(f"Trying to set brightness: {brightness_dev}")
             await self._dev.set_brightness(brightness_dev)
-            self._brightness = brightness
+            self._brightness = self._dev._brightness
             return
 
         # if ATTR_EFFECT in kwargs:

--- a/custom_components/yeelight_bt/manifest.json
+++ b/custom_components/yeelight_bt/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/hcoohb/hass-yeelightbt/issues",
   "dependencies": [],
   "codeowners": ["@hcoohb"],
-  "requirements": ["bluepy>=1.3.0"],
-  "version": "0.11.3",
+  "requirements": ["bleak>=0.14.3"],
+  "version": "0.12.0",
   "iot_class": "local_polling"
 }

--- a/custom_components/yeelight_bt/manifest.json
+++ b/custom_components/yeelight_bt/manifest.json
@@ -8,5 +8,6 @@
   "codeowners": ["@hcoohb"],
   "requirements": ["bleak>=0.14.3"],
   "version": "0.12.0",
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "loggers": ["bleak"]
 }

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -103,11 +103,13 @@ class Lamp:
         self._mode = None  # lamp not available
         self.run_state_changed_cb()
 
-    async def connect(self):
+    async def connect(self, num_tries=3):
         if self._client.is_connected:
             return
-        for i in range(3):
+        for i in range(num_tries):
             try:
+                if i>0:
+                    _LOGGER.debug(f"Connect retry {i}")
                 await self._client.disconnect()
                 self._client =  BleakClient(self._mac, timeout=10)
                 await self._client.connect()

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -82,14 +82,14 @@ class Lamp:
         str_rgb = f"rgb_{self._rgb} " if self._rgb is not None else ""
         str_temp = f"temp_{self._temperature}" if self._temperature is not None else ""
         str_mode = mode_str[self._mode] if self._mode in mode_str else self._mode
+        str_bri = f"bri_{self._brightness} " if self._brightness is not None else ""
         str_rep = (
             f"<Lamp {self._mac} "
             f"{'ON' if self._is_on else 'OFF'} "
             f"mode_{str_mode} "
-            f"{str_rgb}{str_temp}"
+            f"{str_bri}{str_rgb}{str_temp}"
             f">"
         )
-
         return str_rep
 
     def add_callback_on_state_changed(self, func):

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -105,6 +105,9 @@ class Lamp:
             func()
 
     def diconnected_cb(self, client):
+        #ensure we are responding to the newest client:
+        if client != self._client:
+            return
         _LOGGER.debug(f"Client with address {client.address} got disconnected!")
         self._mode = None  # lamp not available
         self._paired = PairMode.UNPAIRED

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -118,6 +118,7 @@ class Lamp:
                 _LOGGER.debug("Request Notify")
                 await self._client.start_notify(NOTIFY_UUID, self.notification_handler)
                 await asyncio.sleep(0.3)
+                _LOGGER.debug("Request Pairing")
                 await self.pair()
                 if not self.versions:
                     await self.get_version()

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -47,8 +47,6 @@ _LOGGER = logging.getLogger(__name__)
 class Lamp:
     """The class that represents a Yeelight lamp
     A Lamp object describe a real world Yeelight lamp.
-    It is linked to an YeelightPeripheral object for BLE transmissions
-    and an YeelightDelegate for BLE notifications handling.
     """
 
     MODE_COLOR = 0x01
@@ -56,8 +54,7 @@ class Lamp:
     MODE_FLOW = 0x03
 
     def __init__(self, mac_address):
-        """ Just setup some vars"""
-        _LOGGER.debug(f"Creating Yeelight Lamp {mac_address}")
+        _LOGGER.debug(f"Initializing Yeelight Lamp {mac_address}")
         self._client =  BleakClient(mac_address, timeout=10)
         self._mac = mac_address
         self._is_on = False
@@ -68,9 +65,7 @@ class Lamp:
         self._paired = True
         self.versions = None
         self._model = "Unknown"
-
         self._state_callbacks = []  # store func to call on state received
-        self._wait_next_cmd = 0
 
     def __str__(self):
         """ The string representation """


### PR DESCRIPTION
Switching to bleak as bluetooth backend as since HA 2022.07 bluepy is no longer available.
This is as a draft for now.
HA core is also working on a bluetooth integration providing at least centralized device discovery.
So things will need to be adapted further later


Resolving #19 