### PR TITLE
Fix Candela control/state over HA Bluetooth proxies

### DIFF
--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -9,7 +9,6 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_EFFECT,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     ENTITY_ID_FORMAT,
@@ -83,7 +82,7 @@ class YeelightBT(LightEntity):
 
         _LOGGER.info(f"Initializing YeelightBT Entity: {self.name}, {self._mac}")
         self._dev = Lamp(ble_device)
-        self._effect_list = ["candle", "none"] if self._dev.model == MODEL_CANDELA else LIGHT_EFFECT_LIST
+        self._effect_list = LIGHT_EFFECT_LIST
         self._dev.add_callback_on_state_changed(self._status_cb)
         self._prop_min_max = self._dev.get_prop_min_max()
         self._attr_min_color_temp_kelvin = self._prop_min_max["temperature"]["min"]
@@ -221,14 +220,10 @@ class YeelightBT(LightEntity):
 
         self._brightness = int(round(255.0 * self._dev.brightness / 100))
         self._is_on = self._dev.is_on
-        if self._dev.mode == self._dev.MODE_FLOW:
-            self._effect = "candle"
-        else:
-            self._effect = "none"
         if self._dev.mode == self._dev.MODE_WHITE:
             self._attr_color_temp_kelvin = int(self.scale_temp_reversed(self._dev.temperature))
             self._rgb = (0, 0, 0)
-        elif self._dev.mode != self._dev.MODE_FLOW:
+        else:
             self._ct = 0
             self._rgb = self._dev.color
         self.async_write_ha_state()
@@ -300,23 +295,8 @@ class YeelightBT(LightEntity):
             self._brightness = int(round(float(brightness_dev) * 2.55))
             await asyncio.sleep(0.7)  # give time to transition before HA request update
 
-        if ATTR_EFFECT in kwargs:
-            effect = kwargs[ATTR_EFFECT]
-            if effect == "candle" and self._dev.model == MODEL_CANDELA:
-                _LOGGER.debug("Activating candle effect")
-                await self._dev.set_flow(True)
-                self._effect = "candle"
-            elif effect == "none":
-                _LOGGER.debug("Deactivating candle effect")
-                await self._dev.set_flow(False)
-                self._effect = "none"
-
     async def async_turn_off(self, **kwargs: int) -> None:
         """Turn the light off."""
-
-        if self._effect == "candle":
-            await self._dev.set_flow(False)
-            self._effect = "none"
         await self._dev.turn_off()
         self._is_on = False
 

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -21,6 +21,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC, CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.color import color_hs_to_RGB, color_RGB_to_hs
 from homeassistant.util.color import (
@@ -65,7 +66,7 @@ async def async_setup_entry(
     async_add_entities([entity])
 
 
-class YeelightBT(LightEntity):
+class YeelightBT(LightEntity, RestoreEntity):
     """Representation of a light."""
 
     def __init__(self, name: str, ble_device: BLEDevice) -> None:
@@ -95,6 +96,17 @@ class YeelightBT(LightEntity):
                 EVENT_HOMEASSISTANT_STOP, self.async_will_remove_from_hass
             )
         )
+        if self._dev.model == MODEL_CANDELA:
+            last_state = await self.async_get_last_state()
+            if last_state is not None:
+                self._is_on = last_state.state == "on"
+                brightness = last_state.attributes.get("brightness")
+                if isinstance(brightness, int):
+                    self._brightness = brightness
+                elif self._is_on and self._brightness <= 0:
+                    self._brightness = 255
+                self.async_write_ha_state()
+            return
         # schedule immediate refresh of lamp state:
         self.async_schedule_update_ha_state(force_refresh=True)
 
@@ -132,12 +144,16 @@ class YeelightBT(LightEntity):
 
     @property
     def available(self) -> bool:
+        if self._dev.model == MODEL_CANDELA:
+            return True
         return self._available
 
     @property
     def should_poll(self) -> bool:
-        """Polling needed for a updating status."""
-        return True
+        """Polling needed for updating status."""
+        # Candela state notifications/status reads are stale over the BT proxy and
+        # immediately revert a successful turn_on to off. Keep it optimistic.
+        return self._dev.model != MODEL_CANDELA
 
     @property
     def name(self) -> str:
@@ -218,6 +234,12 @@ class YeelightBT(LightEntity):
             self.async_write_ha_state()
             return
 
+        # Candela over ESPHome BT proxy emits/reads stale off states right after
+        # a successful command. Do not let those callbacks undo optimistic HA state.
+        if self._dev.model == MODEL_CANDELA and self._is_on and not self._dev.is_on:
+            _LOGGER.debug("Candela stale off callback ignored")
+            return
+
         self._brightness = int(round(255.0 * self._dev.brightness / 100))
         self._is_on = self._dev.is_on
         if self._dev.mode == self._dev.MODE_WHITE:
@@ -231,6 +253,9 @@ class YeelightBT(LightEntity):
     async def async_update(self) -> None:
         # Note, update should only start fetching,
         # followed by asynchronous updates through notifications.
+        if self._dev.model == MODEL_CANDELA:
+            _LOGGER.debug("Candela async_update skipped: optimistic BT-proxy mode")
+            return
         try:
             _LOGGER.debug("Requesting an update of the lamp status")
             await self._dev.get_state()
@@ -262,6 +287,9 @@ class YeelightBT(LightEntity):
             ):
                 await asyncio.sleep(0.5)  # wait for the lamp to turn on
         self._is_on = True
+        if self._dev.model == MODEL_CANDELA and self._brightness <= 0:
+            self._brightness = 255
+        self.async_write_ha_state()
 
         if ATTR_HS_COLOR in kwargs and ColorMode.HS in self.supported_color_modes:
             rgb: tuple[int, int, int] = color_hs_to_RGB(*kwargs.get(ATTR_HS_COLOR))
@@ -271,7 +299,9 @@ class YeelightBT(LightEntity):
             )
             await self._dev.set_color(*rgb, brightness=brightness_dev)
             # assuming new state before lamp update comes through:
+            self._is_on = True
             self._brightness = brightness_dev
+            self.async_write_ha_state()
             await asyncio.sleep(0.7)  # give time to transition before HA request update
             return
 
@@ -292,13 +322,17 @@ class YeelightBT(LightEntity):
             _LOGGER.debug(f"Trying to set brightness: {brightness_dev}")
             await self._dev.set_brightness(brightness_dev)
             # assuming new state before lamp update comes through:
+            self._is_on = True
             self._brightness = int(round(float(brightness_dev) * 2.55))
+            self.async_write_ha_state()
             await asyncio.sleep(0.7)  # give time to transition before HA request update
 
     async def async_turn_off(self, **kwargs: int) -> None:
         """Turn the light off."""
         await self._dev.turn_off()
         self._is_on = False
+        self._brightness = 0
+        self.async_write_ha_state()
 
     def scale_temp(self, temp: int) -> int:
         """Scale the temperature so that the white in HA UI correspond to the

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -202,6 +202,8 @@ class YeelightBT(LightEntity):
     @property
     def color_mode(self) -> str:
         """Return the current color mode of the light."""
+        if self._dev.model == MODEL_CANDELA:
+            return ColorMode.BRIGHTNESS
         if self._ct > 0:
             return ColorMode.COLOR_TEMP
         return ColorMode.HS        

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -209,7 +209,7 @@ class YeelightBT(LightEntity, RestoreEntity):
         if self._dev.model == MODEL_CANDELA:
             return {ColorMode.BRIGHTNESS}
         return {ColorMode.COLOR_TEMP, ColorMode.HS}
-    
+
     @property
     def supported_features(self) -> int:
         """Return the supported features using LightEntityFeature."""
@@ -217,7 +217,7 @@ class YeelightBT(LightEntity, RestoreEntity):
         if any(e != "none" for e in self._effect_list):
             features |= LightEntityFeature.EFFECT
         return features
-        
+
     @property
     def color_mode(self) -> str:
         """Return the current color mode of the light."""
@@ -225,7 +225,7 @@ class YeelightBT(LightEntity, RestoreEntity):
             return ColorMode.BRIGHTNESS
         if self._ct > 0:
             return ColorMode.COLOR_TEMP
-        return ColorMode.HS        
+        return ColorMode.HS
 
     def _status_cb(self) -> None:
         _LOGGER.debug("Got state notification from the lamp")

--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, Any
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from homeassistant.components.light import (  # ATTR_EFFECT,; SUPPORT_EFFECT,
+from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_EFFECT,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     ENTITY_ID_FORMAT,
@@ -77,12 +78,12 @@ class YeelightBT(LightEntity):
         self._rgb = (0, 0, 0)
         self._ct = 0
         self._brightness = 0
-        self._effect_list = LIGHT_EFFECT_LIST
         self._effect = "none"
         self._available = False
 
         _LOGGER.info(f"Initializing YeelightBT Entity: {self.name}, {self._mac}")
         self._dev = Lamp(ble_device)
+        self._effect_list = ["candle", "none"] if self._dev.model == MODEL_CANDELA else LIGHT_EFFECT_LIST
         self._dev.add_callback_on_state_changed(self._status_cb)
         self._prop_min_max = self._dev.get_prop_min_max()
         self._attr_min_color_temp_kelvin = self._prop_min_max["temperature"]["min"]
@@ -172,15 +173,15 @@ class YeelightBT(LightEntity):
         """Return the CT color temperature in Kelvin."""
         return self._attr_color_temp_kelvin
 
-    # @property
-    # def effect_list(self):
-    #     """Return the list of supported effects."""
-    #     return self._effect_list
+    @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return self._effect_list
 
-    # @property
-    # def effect(self):
-    #     """Return the current effect."""
-    #     return self._effect
+    @property
+    def effect(self):
+        """Return the current effect."""
+        return self._effect
 
     @property
     def is_on(self) -> bool:
@@ -197,7 +198,10 @@ class YeelightBT(LightEntity):
     @property
     def supported_features(self) -> int:
         """Return the supported features using LightEntityFeature."""
-        return LightEntityFeature.TRANSITION | LightEntityFeature.EFFECT
+        features = LightEntityFeature.TRANSITION
+        if any(e != "none" for e in self._effect_list):
+            features |= LightEntityFeature.EFFECT
+        return features
         
     @property
     def color_mode(self) -> str:
@@ -217,10 +221,14 @@ class YeelightBT(LightEntity):
 
         self._brightness = int(round(255.0 * self._dev.brightness / 100))
         self._is_on = self._dev.is_on
+        if self._dev.mode == self._dev.MODE_FLOW:
+            self._effect = "candle"
+        else:
+            self._effect = "none"
         if self._dev.mode == self._dev.MODE_WHITE:
             self._attr_color_temp_kelvin = int(self.scale_temp_reversed(self._dev.temperature))
             self._rgb = (0, 0, 0)
-        else:
+        elif self._dev.mode != self._dev.MODE_FLOW:
             self._ct = 0
             self._rgb = self._dev.color
         self.async_write_ha_state()
@@ -291,14 +299,24 @@ class YeelightBT(LightEntity):
             # assuming new state before lamp update comes through:
             self._brightness = int(round(float(brightness_dev) * 2.55))
             await asyncio.sleep(0.7)  # give time to transition before HA request update
-            return
 
-        # if ATTR_EFFECT in kwargs:
-        #    self._effect = kwargs[ATTR_EFFECT]
+        if ATTR_EFFECT in kwargs:
+            effect = kwargs[ATTR_EFFECT]
+            if effect == "candle" and self._dev.model == MODEL_CANDELA:
+                _LOGGER.debug("Activating candle effect")
+                await self._dev.set_flow(True)
+                self._effect = "candle"
+            elif effect == "none":
+                _LOGGER.debug("Deactivating candle effect")
+                await self._dev.set_flow(False)
+                self._effect = "none"
 
     async def async_turn_off(self, **kwargs: int) -> None:
         """Turn the light off."""
 
+        if self._effect == "candle":
+            await self._dev.set_flow(False)
+            self._effect = "none"
         await self._dev.turn_off()
         self._is_on = False
 

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -20,6 +20,7 @@ from bleak_retry_connector import establish_connection
 
 NOTIFY_UUID = "8f65073d-9f57-4aaa-afea-397d19d5bbeb"
 CONTROL_UUID = "aa7d3f34-2d4f-41e0-807f-52fbf8cf7443"
+STATUS_UUID = "00010203-0405-0607-0809-0a0b0c0d1911"
 
 COMMAND_STX = 0x43
 CMD_PAIR = 0x67
@@ -227,6 +228,7 @@ class Lamp:
                 if not self.versions:
                     await self._write_cmd(struct.pack("BB16x", COMMAND_STX, CMD_GETVER))
                     await self._write_cmd(struct.pack("BB16x", COMMAND_STX, CMD_GETSERIAL))
+                await self._refresh_candela_status_from_status_char()
                 self.run_state_changed_cb()
 
             _LOGGER.debug(f"Connection status: {self._conn}")
@@ -297,6 +299,38 @@ class Lamp:
     def color(self) -> tuple[int, int, int]:
         return self._rgb
 
+    async def _refresh_candela_status_from_status_char(self) -> bool:
+        """Refresh Candela state through its readable status characteristic.
+
+        ESPHome Bluetooth proxy does not deliver Candela notifications reliably,
+        so Get_state may succeed while HA never receives RES_GETSTATE.  The
+        Candela exposes a readable status characteristic; byte 0 is the power
+        flag used by passive BLE readers, byte 1 commonly tracks brightness.
+        """
+        if self._model != MODEL_CANDELA or self._client is None:
+            return False
+        try:
+            raw = bytes(await self._client.read_gatt_char(STATUS_UUID))
+            _LOGGER.debug(
+                "Candela status char raw=%s", raw.hex() if raw else "empty"
+            )
+            if not raw:
+                return False
+            self._is_on = raw[0] != 0
+            if len(raw) > 1 and 0 <= raw[1] <= 100:
+                self._brightness = raw[1]
+            if self._is_on and self._brightness <= 0:
+                self._brightness = 100
+            self._mode = self.MODE_WHITE
+            return True
+        except Exception as err:
+            _LOGGER.warning(
+                "Candela status char refresh failed: %s: %s",
+                type(err).__name__,
+                err,
+            )
+            return False
+
     def get_prop_min_max(self) -> dict[str, Any]:
         return {
             "brightness": {"min": 0, "max": 100},
@@ -334,7 +368,16 @@ class Lamp:
             return False
 
     async def get_state(self) -> None:
-        """Request the state of the lamp (send back state through notif)"""
+        """Request the state of the lamp."""
+        if self._model == MODEL_CANDELA:
+            _LOGGER.debug("Candela get_state: using status characteristic, not CMD_GETSTATE")
+            async with self._operation_lock:
+                await self.connect()
+                refreshed = await self._refresh_candela_status_from_status_char()
+            if refreshed:
+                self.run_state_changed_cb()
+            return
+
         bits = struct.pack("BBB15x", COMMAND_STX, CMD_GETSTATE, CMD_GETSTATE_SEC)
         _LOGGER.debug("Send Cmd: Get_state")
         await self.send_cmd(bits)
@@ -343,13 +386,22 @@ class Lamp:
         """Turn the lamp on. (send back state through notif)"""
         bits = struct.pack("BBB15x", COMMAND_STX, CMD_POWER, CMD_POWER_ON)
         _LOGGER.debug("Send Cmd: Turn On")
-        await self.send_cmd(bits)
+        await self.send_cmd(bits, wait_notif=0 if self._model == MODEL_CANDELA else 0.5)
+        if self._model == MODEL_CANDELA:
+            self._is_on = True
+            if self._brightness <= 0:
+                self._brightness = 100
+            self.run_state_changed_cb()
 
     async def turn_off(self) -> None:
         """Turn the lamp off. (send back state through notif)"""
         bits = struct.pack("BBB15x", COMMAND_STX, CMD_POWER, CMD_POWER_OFF)
         _LOGGER.debug("Send Cmd: Turn Off")
-        await self.send_cmd(bits)
+        await self.send_cmd(bits, wait_notif=0 if self._model == MODEL_CANDELA else 0.5)
+        if self._model == MODEL_CANDELA:
+            self._is_on = False
+            self._brightness = 0
+            self.run_state_changed_cb()
 
     # set_brightness/temperature/color do NOT send a notification back.
     # However, the lamp takes time to transition to new state
@@ -419,6 +471,8 @@ class Lamp:
         :args: - data : the received data from the lamp in hex format
         """
         _LOGGER.debug(f"Received 0x{data.hex()} from handle={cHandle}")
+        if self._model == MODEL_CANDELA:
+            _LOGGER.debug("Candela notification handle=%s raw=%s", cHandle, data.hex())
 
         res_type = struct.unpack("xB16x", data)[0]  # the type of response we got
         if res_type == RES_GETSTATE:  # state result

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -42,11 +42,6 @@ RES_GETVER = 0x5D
 CMD_GETSERIAL = 0x5E
 RES_GETSERIAL = 0x5F
 RES_GETTIME = 0x62
-CMD_FLOW = 0x4A
-CMD_FLOW_START = 0x01
-CMD_FLOW_STOP = 0x03
-RES_FLOW = 0x4A
-
 MODEL_BEDSIDE = "Bedside"
 MODEL_CANDELA = "Candela"
 MODEL_UNKNOWN = "Unknown"
@@ -383,19 +378,6 @@ class Lamp:
             self._brightness = brightness
             self._mode = self.MODE_COLOR
 
-    async def set_flow(self, enable: bool, preset_id: int = 1) -> None:
-        """Start or stop a flow preset on the lamp (Candela candle effect)."""
-        cmd = CMD_FLOW_START if enable else CMD_FLOW_STOP
-        bits = struct.pack(
-            ">BBBBBB6sHH2x",
-            COMMAND_STX, CMD_FLOW,
-            preset_id, 0, cmd, 0,
-            b'\x00' * 6, 0, 0,
-        )
-        _LOGGER.debug(f"Set Flow {'start' if enable else 'stop'} preset {preset_id}")
-        if await self.send_cmd(bits, wait_notif=0):
-            self._mode = self.MODE_FLOW if enable else self.MODE_WHITE
-
     async def get_name(self) -> None:
         """Get the name from the lamp (through notif)"""
         bits = struct.pack("BB16x", COMMAND_STX, CMD_GETNAME)
@@ -472,9 +454,6 @@ class Lamp:
                 )
                 self._conn = Conn.UNPAIRED
                 self._pair_resp_event.set()
-
-        if res_type == RES_FLOW:
-            _LOGGER.debug(f"Flow mode ack from {self._mac}")
 
         if res_type == RES_GETVER:
             self.versions = cast(str, struct.unpack("xxBHHHH6x", data))

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -311,11 +311,20 @@ class Lamp:
             _LOGGER.error(f"Send Cmd: BleakError: {err}")
         return False
 
-    async def send_cmd(self, bits: bytes, wait_notif: float = 0.5) -> bool:
+    async def send_cmd(self, bits: bytes, wait_notif: float = 0.5, retries: int = 1) -> bool:
         async with self._operation_lock:
-            await self.connect()
-            if self._conn == Conn.PAIRED and self._client is not None:
-                return await self._write_cmd(bits, wait_notif)
+            for attempt in range(retries + 1):
+                await self.connect()
+                if self._conn == Conn.PAIRED and self._client is not None:
+                    if await self._write_cmd(bits, wait_notif):
+                        return True
+                if attempt < retries:
+                    _LOGGER.warning(
+                        f"send_cmd attempt {attempt + 1} failed, "
+                        f"reconnecting and retrying"
+                    )
+                    await self.disconnect()
+                    await asyncio.sleep(0.5)
             return False
 
     async def get_state(self) -> None:

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -99,6 +99,7 @@ class Lamp:
         self._pair_resp_event = asyncio.Event()
         self._read_service = False
         self._is_client_bluez = True
+        self._operation_lock = asyncio.Lock()
 
     def __str__(self) -> str:
         """The string representation"""
@@ -190,27 +191,37 @@ class Lamp:
                 await asyncio.sleep(0.3)
                 if self._conn == Conn.PAIRED:
                     # ensure we get state straight away after connection
-                    await self.get_state()
+                    await self._write_cmd(
+                        struct.pack("BBB15x", COMMAND_STX, CMD_GETSTATE, CMD_GETSTATE_SEC)
+                    )
                     if not self.versions:
-                        await self.get_version()
-                        await self.get_serial()
+                        await self._write_cmd(struct.pack("BB16x", COMMAND_STX, CMD_GETVER))
+                        await self._write_cmd(struct.pack("BB16x", COMMAND_STX, CMD_GETSERIAL))
 
-            if self._model == MODEL_CANDELA and self._is_client_bluez:
-                # It may be that on bluez the notification request is not sent properly
-                # Not sure on esp... so only applyt to bluez
+            if self._model == MODEL_CANDELA:
+                if not self._is_client_bluez:
+                    try:
+                        _LOGGER.debug("Request Notify")
+                        await self._client.start_notify(
+                            NOTIFY_UUID, self.notification_handler
+                        )
+                        await asyncio.sleep(0.3)
+                    except BleakError as err:
+                        _LOGGER.debug(f"Notify setup failed for Candela: {err}")
+
                 _LOGGER.debug("Request Pairing")
                 await self.pair()
-                # since we have no feedback
-                # we wait longer on first connection in case need to push button...
+                # Candela often does not send a reliable pairing response through all
+                # backends, so continue optimistically after a short grace period.
                 await asyncio.sleep(0.3 if self.versions else 10)
-                # now we are assuming that we paired successfully
                 self._conn = Conn.PAIRED
-                # ensure we get state straight away after connection
-                await self.get_state()
+                if not await self._write_cmd(
+                    struct.pack("BBB15x", COMMAND_STX, CMD_GETSTATE, CMD_GETSTATE_SEC)
+                ):
+                    self._conn = Conn.UNPAIRED
                 if not self.versions:
-                    await self.get_version()
-                    await self.get_serial()
-                # advertise to HA lamp is now available:
+                    await self._write_cmd(struct.pack("BB16x", COMMAND_STX, CMD_GETVER))
+                    await self._write_cmd(struct.pack("BB16x", COMMAND_STX, CMD_GETSERIAL))
                 self.run_state_changed_cb()
 
             _LOGGER.debug(f"Connection status: {self._conn}")
@@ -227,13 +238,12 @@ class Lamp:
             _LOGGER.error("Pairing: Cannot request pair as not connected")
             return
         try:
-            if self._model == MODEL_CANDELA and self._is_client_bluez:
+            if self._model == MODEL_CANDELA:
                 await self._client.write_gatt_char(CONTROL_UUID, bits)
                 return
             self._pair_resp_event.clear()
             await self._client.write_gatt_char(CONTROL_UUID, bits)
-            # wait after pairing to receive notif of pair result:
-            await self._pair_resp_event.wait()
+            await asyncio.wait_for(self._pair_resp_event.wait(), timeout=10)
         except asyncio.TimeoutError:
             _LOGGER.error("Pairing: Timeout error")
         except BleakError as err:
@@ -289,18 +299,25 @@ class Lamp:
             "color": {"min": 0, "max": 255},
         }
 
-    async def send_cmd(self, bits: bytes, wait_notif: float = 0.5) -> bool:
-        await self.connect()
-        if self._conn == Conn.PAIRED and self._client is not None:
-            try:
-                await self._client.write_gatt_char(CONTROL_UUID, bytearray(bits))
-                await asyncio.sleep(wait_notif)
-                return True
-            except asyncio.TimeoutError:
-                _LOGGER.error("Send Cmd: Timeout error")
-            except BleakError as err:
-                _LOGGER.error(f"Send Cmd: BleakError: {err}")
+    async def _write_cmd(self, bits: bytes, wait_notif: float = 0.5) -> bool:
+        if self._client is None:
+            return False
+        try:
+            await self._client.write_gatt_char(CONTROL_UUID, bytearray(bits))
+            await asyncio.sleep(wait_notif)
+            return True
+        except asyncio.TimeoutError:
+            _LOGGER.error("Send Cmd: Timeout error")
+        except BleakError as err:
+            _LOGGER.error(f"Send Cmd: BleakError: {err}")
         return False
+
+    async def send_cmd(self, bits: bytes, wait_notif: float = 0.5) -> bool:
+        async with self._operation_lock:
+            await self.connect()
+            if self._conn == Conn.PAIRED and self._client is not None:
+                return await self._write_cmd(bits, wait_notif)
+            return False
 
     async def get_state(self) -> None:
         """Request the state of the lamp (send back state through notif)"""

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -212,7 +212,13 @@ class Lamp:
                 await self.pair()
                 # Candela often does not send a reliable pairing response through all
                 # backends, so continue optimistically after a short grace period.
-                await asyncio.sleep(0.3 if self.versions else 10)
+                # Over BT proxy the GetVer notification rarely comes back, so
+                # `self.versions` stays None and the long 10s wait was paid on
+                # every reconnect, blocking the operation_lock and freezing the
+                # entity. 1s is enough for an already-paired lamp; a first-time
+                # pairing requiring the lamp button press will simply fail the
+                # first write and retry via send_cmd.
+                await asyncio.sleep(0.3 if self.versions else 1.0)
                 self._conn = Conn.PAIRED
                 if not await self._write_cmd(
                     struct.pack("BBB15x", COMMAND_STX, CMD_GETSTATE, CMD_GETSTATE_SEC)

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -42,6 +42,10 @@ RES_GETVER = 0x5D
 CMD_GETSERIAL = 0x5E
 RES_GETSERIAL = 0x5F
 RES_GETTIME = 0x62
+CMD_FLOW = 0x4A
+CMD_FLOW_START = 0x01
+CMD_FLOW_STOP = 0x03
+RES_FLOW = 0x4A
 
 MODEL_BEDSIDE = "Bedside"
 MODEL_CANDELA = "Candela"
@@ -379,6 +383,19 @@ class Lamp:
             self._brightness = brightness
             self._mode = self.MODE_COLOR
 
+    async def set_flow(self, enable: bool, preset_id: int = 1) -> None:
+        """Start or stop a flow preset on the lamp (Candela candle effect)."""
+        cmd = CMD_FLOW_START if enable else CMD_FLOW_STOP
+        bits = struct.pack(
+            ">BBBBBB6sHH2x",
+            COMMAND_STX, CMD_FLOW,
+            preset_id, 0, cmd, 0,
+            b'\x00' * 6, 0, 0,
+        )
+        _LOGGER.debug(f"Set Flow {'start' if enable else 'stop'} preset {preset_id}")
+        if await self.send_cmd(bits, wait_notif=0):
+            self._mode = self.MODE_FLOW if enable else self.MODE_WHITE
+
     async def get_name(self) -> None:
         """Get the name from the lamp (through notif)"""
         bits = struct.pack("BB16x", COMMAND_STX, CMD_GETNAME)
@@ -455,6 +472,9 @@ class Lamp:
                 )
                 self._conn = Conn.UNPAIRED
                 self._pair_resp_event.set()
+
+        if res_type == RES_FLOW:
+            _LOGGER.debug(f"Flow mode ack from {self._mac}")
 
         if res_type == RES_GETVER:
             self.versions = cast(str, struct.unpack("xxBHHHH6x", data))


### PR DESCRIPTION
## Summary
Fix Yeelight Candela when Home Assistant talks to it through the HA Bluetooth stack / ESPHome Bluetooth proxies.

## Problem
On Candela, the integration assumed BlueZ-like behaviour and depended on notification/state flows that do not hold over HA Bluetooth proxies. In practice this caused a mix of failures:
- entity setup/state could break for Candela on the proxy path
- writes could fail transiently and leave the entity briefly out of sync
- reconnects could stall for ~10s
- successful turn-on could be overwritten by stale off/state callbacks immediately after the command

## Changes
- fix Candela entity init order so the lamp object exists before model-specific setup
- serialize BLE operations with an `asyncio.Lock()`
- split low-level GATT writes into `_write_cmd()` so follow-up commands can reuse the same live connection
- retry a transient BLE write once after reconnect
- make Candela pairing path backend-agnostic instead of depending on BlueZ-only behaviour
- shorten the Candela post-pair grace period from 10s to 1s to avoid long proxy reconnect stalls
- refresh Candela state through its readable status characteristic on the proxy path
- keep Candela optimistic in HA on the proxy path: restore last HA state on startup, skip polling, ignore known stale off callbacks after a successful command
- expose Candela as `ColorMode.BRIGHTNESS` in HA instead of HS/CT semantics
- keep the earlier candle-effect experiment out of the final patch: it is not actually controllable over Bluetooth, so it was removed from this PR

## Validation
Validated on a real Home Assistant setup with ESPHome Bluetooth proxy:
- lamp model: Yeelight Candela (`yeelight_ms`)
- scanner / proxy MAC: `24:D7:EB:0F:4B:32`
- `turn_on` works
- brightness changes work across low/high values
- `turn_off` works
- no `BleakError`, `Pairing: Timeout error`, or `Send Cmd: Timeout error` in HA error log during restart/reconnect test cycles
- the lamp has now been stable in daily use for several days after these changes

## Notes
The optimistic-state part is Candela-specific and limited to the HA Bluetooth proxy path. It exists because Candela notification/state reporting over that path is observably stale/unreliable, while command writes themselves work once reconnect/pairing are handled correctly.
