### PR TITLE
Fix Candela color mode reporting

### DIFF
--- a/custom_components/yeelight_bt/light.py
+++ b/custom_components/yeelight_bt/light.py
@@ -202,6 +202,8 @@ class YeelightBT(LightEntity):
     @property
     def color_mode(self) -> str:
         """Return the current color mode of the light."""
+        if self._dev.model == MODEL_CANDELA:
+            return ColorMode.BRIGHTNESS
         if self._ct > 0:
             return ColorMode.COLOR_TEMP
         return ColorMode.HS        


### PR DESCRIPTION
## Summary

Fix Candela's reported `color_mode` so it matches its advertised `supported_color_modes`.

Candela already reports `supported_color_modes` as `{ColorMode.BRIGHTNESS}`, but the generic `color_mode` branch could still return `ColorMode.HS`. Home Assistant requires the returned `color_mode` to be present in `supported_color_modes`, so Candela can fail with errors like:

```text
light.candela ... set to unsupported color mode hs, expected one of {ColorMode.BRIGHTNESS}
```

This PR returns `ColorMode.BRIGHTNESS` for Candela before the generic colour-temperature/HS logic.

## Context

This is the narrow colour-mode contract fix for #69. It overlaps with the broader Candela Bluetooth proxy work in #79, but keeps this specific failure isolated and easy to review.

## Validation

- `python -m py_compile custom_components/yeelight_bt/light.py`
- Verified against a live Home Assistant failure trace showing Candela rejected because it reported `hs` while supporting only `brightness`.

### Live Home Assistant validation

Validated the patch on a live Home Assistant Core `2026.5.4` instance after copying the change into `/config/custom_components/yeelight_bt/light.py` and restarting Home Assistant so the custom component was reloaded.

Results:

- Direct brightness-only `light.turn_on` on a Candela entity succeeded.
- The Candela entity read back as:
  - `state: on`
  - `supported_color_modes: [brightness]`
  - `color_mode: brightness`
- A mixed light-group service call that previously failed through Candela completed without the unsupported colour-mode error.
- A downstream automation using that light-group path completed cleanly after the patch.

This confirms the original failure path is cleared: Candela no longer reports `hs` while advertising brightness-only support.
